### PR TITLE
update --dryrun to --dry-run in configuration.md

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,7 +1,7 @@
 # Configuration
 
 The configuration is managed via the config file `.k8s-image-swapper.yaml`.
-Some options can be overriden via parameters, e.g. `--dryrun`.
+Some options can be overriden via parameters, e.g. `--dry-run`.
 
 ## Dry Run
 


### PR DESCRIPTION
docs say --dryrun is the flag but in ghcr.io/estahn/k8s-image-swapper:1.1.0 `k8s-image-swapper --help` shows 

```
/ # ./k8s-image-swapper --help
Mirror images into your own registry and swap image references automatically.

A mutating webhook for Kubernetes, pointing the images to a new location.

Usage:
  k8s-image-swapper [flags]

Flags:
      --config string           config file (default is $HOME/.k8s-image-swapper.yaml)
      --dry-run                 If true, print the action taken without taking it (default true)
  -h, --help                    help for k8s-image-swapper
      --listen-address string   Address on which to expose the webhook (default ":8443")
      --log-format string       Format of the log messages. Valid levels: [json, console] (default "json")
      --log-level string        Only log messages with the given severity or above. Valid levels: [debug, info, warn, error, fatal] (default "info")
      --tls-cert-file string    File containing the TLS certificate
      --tls-key-file string     File containing the TLS private key
```