### PR TITLE
update configuration.md with serviceaccount/tf example

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -44,7 +44,7 @@ Choose from one of the strategies below or an alternative if needed.
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
         "StringEquals": {
-          "$${oidc_image_swapper_role_arn}:sub": "system:serviceaccount:${k8s_image_swapper_namespace}:${k8s_image_swapper_serviceaccount_name}"
+          "${oidc_image_swapper_role_arn}:sub": "system:serviceaccount:${k8s_image_swapper_namespace}:${k8s_image_swapper_serviceaccount_name}"
         }
       }
     }


### PR DESCRIPTION
- add info on setting up aws serviceaccount role
- add new terraform example section for setting up helm chart along with service account role/policy.