### PR TITLE
fix: image scan in test action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,13 @@ jobs:
     - name: Unshallow
       run: git fetch --prune --unshallow
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+
     - name: Setup Go
       uses: actions/setup-go@v2.1.4
       with:
@@ -103,7 +110,7 @@ jobs:
           ${{ runner.os }}-go-
 
     - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v2.7.0
+      uses: goreleaser/goreleaser-action@v2.8.0
       with:
         version: latest
         args: release --rm-dist --skip-validate --skip-publish


### PR DESCRIPTION
I  noticed the `test` action was failing due to QEMU/buildx not being configured