### PR TITLE
build: fix conventional labels type structure

### DIFF
--- a/.github/workflows/conventional-label.yaml
+++ b/.github/workflows/conventional-label.yaml
@@ -9,7 +9,9 @@ jobs:
     steps:
       - uses: bcoe/conventional-release-labels@v1
         with:
-          type_labels:
-            feat: feature
-            fix: bugfix
-            breaking: breaking-change
+          type_labels: >
+            {
+              "feat": "feature",
+              "fix": "bugfix",
+              "breaking": "breaking-change"
+            }


### PR DESCRIPTION
Hi,

I noticed that the [conventional labels actions](https://github.com/estahn/k8s-image-swapper/actions/workflows/conventional-label.yaml) has never worked. The reason for that is the structure of the `type_labels` property which I have provided a fix for in this PR.