### PR TITLE
Fix data race issue on copyFn when there are multiple containers or initContainers

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -81,6 +81,11 @@ A mutating webhook for Kubernetes, pointing the images to a new location.`,
 			log.Err(err).Str("policy", cfg.ImageCopyPolicy).Msg("parsing image copy policy failed")
 		}
 
+		imageCopyDeadline := config.DefaultImageCopyDeadline
+		if cfg.ImageCopyDeadline != 0 {
+			imageCopyDeadline = cfg.ImageCopyDeadline
+		}
+
 		imagePullSecretProvider := setupImagePullSecretsProvider()
 
 		wh, err := webhook.NewImageSwapperWebhookWithOpts(
@@ -89,6 +94,7 @@ A mutating webhook for Kubernetes, pointing the images to a new location.`,
 			webhook.ImagePullSecretsProvider(imagePullSecretProvider),
 			webhook.ImageSwapPolicy(imageSwapPolicy),
 			webhook.ImageCopyPolicy(imageCopyPolicy),
+			webhook.ImageCopyDeadline(imageCopyDeadline),
 		)
 		if err != nil {
 			log.Err(err).Msg("error creating webhook")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,9 +38,14 @@ The option `imageSwapPolicy` (default: `exists`) defines the mutation strategy u
 The option `imageCopyPolicy` (default: `delayed`) defines the image copy strategy used.
 
 * `delayed`: Submits the copy job to a process queue and moves on.
-* `immediate`: Submits the copy job to a process queue and waits for it to finish (deadline 8s).
-* `force`: Attempts to immediately copy the image (deadline 8s).
+* `immediate`: Submits the copy job to a process queue and waits for it to finish (deadline defined by `imageCopyDeadline`).
+* `force`: Attempts to immediately copy the image (deadline defined by `imageCopyDeadline`).
 
+## ImageCopyDeadline
+
+The option `imageCopyDeadline` (default: `8s`) defines the duration after which the image copy if aborted.
+
+This option only applies for `immediate` and `force` image copy strategies.
 
 
 ## Source

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,7 +23,10 @@ package config
 
 import (
 	"fmt"
+	"time"
 )
+
+const DefaultImageCopyDeadline = 8 * time.Second
 
 type Config struct {
 	LogLevel  string `yaml:"logLevel" validate:"oneof=trace debug info warn error fatal"`
@@ -31,11 +34,13 @@ type Config struct {
 
 	ListenAddress string
 
-	DryRun          bool   `yaml:"dryRun"`
-	ImageSwapPolicy string `yaml:"imageSwapPolicy" validate:"oneof=always exists"`
-	ImageCopyPolicy string `yaml:"imageCopyPolicy" validate:"oneof=delayed immediate force"`
-	Source          Source `yaml:"source"`
-	Target          Target `yaml:"target"`
+	DryRun            bool          `yaml:"dryRun"`
+	ImageSwapPolicy   string        `yaml:"imageSwapPolicy" validate:"oneof=always exists"`
+	ImageCopyPolicy   string        `yaml:"imageCopyPolicy" validate:"oneof=delayed immediate force"`
+	ImageCopyDeadline time.Duration `yaml:"imageCopyDeadline"`
+
+	Source Source `yaml:"source"`
+	Target Target `yaml:"target"`
 
 	TLSCertFile string
 	TLSKeyFile  string

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -1,13 +1,15 @@
 package registry
 
+import "context"
+
 // Client provides methods required to be implemented by the various target registry clients, e.g. ECR, Docker, Quay.
 type Client interface {
-	CreateRepository(string) error
+	CreateRepository(ctx context.Context, name string) error
 	RepositoryExists() bool
 	CopyImage() error
 	PullImage() error
 	PutImage() error
-	ImageExists(ref string) bool
+	ImageExists(ctx context.Context, ref string) bool
 
 	// Endpoint returns the domain of the registry
 	Endpoint() string

--- a/pkg/secrets/dummy.go
+++ b/pkg/secrets/dummy.go
@@ -1,6 +1,10 @@
 package secrets
 
-import v1 "k8s.io/api/core/v1"
+import (
+	"context"
+
+	v1 "k8s.io/api/core/v1"
+)
 
 // DummyImagePullSecretsProvider does nothing
 type DummyImagePullSecretsProvider struct {
@@ -12,6 +16,6 @@ func NewDummyImagePullSecretsProvider() ImagePullSecretsProvider {
 }
 
 // GetImagePullSecrets returns an empty ImagePullSecretsResult
-func (p *DummyImagePullSecretsProvider) GetImagePullSecrets(pod *v1.Pod) (*ImagePullSecretsResult, error) {
+func (p *DummyImagePullSecretsProvider) GetImagePullSecrets(ctx context.Context, pod *v1.Pod) (*ImagePullSecretsResult, error) {
 	return NewImagePullSecretsResult(), nil
 }

--- a/pkg/secrets/dummy_test.go
+++ b/pkg/secrets/dummy_test.go
@@ -1,6 +1,7 @@
 package secrets
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -41,7 +42,7 @@ func TestDummyImagePullSecretsProvider_GetImagePullSecrets(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &DummyImagePullSecretsProvider{}
-			got, err := p.GetImagePullSecrets(tt.args.pod)
+			got, err := p.GetImagePullSecrets(context.Background(), tt.args.pod)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetImagePullSecrets() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/secrets/kubernetes_test.go
+++ b/pkg/secrets/kubernetes_test.go
@@ -89,7 +89,7 @@ func TestKubernetesCredentialProvider_GetImagePullSecrets(t *testing.T) {
 	_, _ = clientSet.CoreV1().Secrets("test-ns").Create(context.TODO(), podSecret, metav1.CreateOptions{})
 
 	provider := NewKubernetesImagePullSecretsProvider(clientSet)
-	result, err := provider.GetImagePullSecrets(pod)
+	result, err := provider.GetImagePullSecrets(context.Background(), pod)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)

--- a/pkg/secrets/provider.go
+++ b/pkg/secrets/provider.go
@@ -1,7 +1,11 @@
 package secrets
 
-import v1 "k8s.io/api/core/v1"
+import (
+	"context"
+
+	v1 "k8s.io/api/core/v1"
+)
 
 type ImagePullSecretsProvider interface {
-	GetImagePullSecrets(pod *v1.Pod) (*ImagePullSecretsResult, error)
+	GetImagePullSecrets(ctx context.Context, pod *v1.Pod) (*ImagePullSecretsResult, error)
 }

--- a/pkg/webhook/image_copier.go
+++ b/pkg/webhook/image_copier.go
@@ -1,0 +1,171 @@
+package webhook
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+
+	"github.com/containers/image/v5/docker/reference"
+	ctypes "github.com/containers/image/v5/types"
+	"github.com/rs/zerolog/log"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// struct representing a job of copying an image with its subcontext
+type ImageCopier struct {
+	sourcePod      *corev1.Pod
+	sourceImageRef ctypes.ImageReference
+	targetImage    string
+
+	imagePullPolicy corev1.PullPolicy
+	imageSwapper    *ImageSwapper
+
+	context       context.Context
+	cancelContext context.CancelFunc
+}
+
+var ErrImageAlreadyPresent = errors.New("image already present in target registry")
+
+// replace the default context with a new one with a timeout
+func (ic *ImageCopier) withDeadline() *ImageCopier {
+	imageCopierContext, imageCopierContextCancel := context.WithTimeout(ic.context, ic.imageSwapper.imageCopyDeadline)
+	ic.context = imageCopierContext
+	ic.cancelContext = imageCopierContextCancel
+	return ic
+}
+
+// start the image copy job
+func (ic *ImageCopier) start() {
+	if _, hasDeadline := ic.context.Deadline(); hasDeadline {
+		defer ic.cancelContext()
+	}
+
+	// list of actions to execute in order to copy an image
+	tasks := []func() error{
+		ic.taskCheckImage,
+		ic.taskCreateRepository,
+		ic.taskCopyImage,
+	}
+
+	for _, task := range tasks {
+		err := ic.run(task)
+
+		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) {
+				log.Ctx(ic.context).Err(err).Msg("timeout during image copy")
+			}
+			if errors.Is(err, ErrImageAlreadyPresent) {
+				log.Ctx(ic.context).Trace().Msgf("image copy aborted: %s", err.Error())
+			}
+			break
+		}
+	}
+}
+
+// run a task and update the copy status
+func (ic *ImageCopier) run(task func() error) error {
+	if err := ic.context.Err(); err != nil {
+		return err
+	}
+
+	return task()
+}
+
+func (ic *ImageCopier) taskCheckImage() error {
+	registryClient := ic.imageSwapper.registryClient
+
+	imageAlreadyExists := registryClient.ImageExists(ic.context, ic.targetImage) && ic.imagePullPolicy != corev1.PullAlways
+
+	if err := ic.context.Err(); err != nil {
+		return err
+	} else if imageAlreadyExists {
+		return ErrImageAlreadyPresent
+	}
+
+	return nil
+}
+
+func (ic *ImageCopier) taskCreateRepository() error {
+	createRepoName := reference.TrimNamed(ic.sourceImageRef.DockerReference()).String()
+
+	log.Ctx(ic.context).Debug().Str("repository", createRepoName).Msg("create repository")
+
+	return ic.imageSwapper.registryClient.CreateRepository(ic.context, createRepoName)
+}
+
+func (ic *ImageCopier) taskCopyImage() error {
+	ctx := ic.context
+	sourceImage := ic.sourceImageRef.DockerReference().String()
+	targetImage := ic.targetImage
+
+	// Retrieve secrets and auth credentials
+	imagePullSecrets, err := ic.imageSwapper.imagePullSecretProvider.GetImagePullSecrets(ctx, ic.sourcePod)
+	// not possible at the moment
+	if err != nil {
+		return err
+	}
+
+	authFile, err := imagePullSecrets.AuthFile()
+	if err != nil {
+		log.Ctx(ctx).Err(err).Msg("failed generating authFile")
+	}
+
+	defer func() {
+		if err := os.RemoveAll(authFile.Name()); err != nil {
+			log.Ctx(ctx).Err(err).Str("file", authFile.Name()).Msg("failed removing auth file")
+		}
+	}()
+
+	log.Ctx(ctx).Trace().Msg("copy image")
+
+	// Copy image
+	// TODO: refactor to use structure instead of passing file name / string
+	//
+	//	or transform registryClient creds into auth compatible form, e.g.
+	//	{"auths":{"aws_account_id.dkr.ecr.region.amazonaws.com":{"username":"AWS","password":"..."	}}}
+	if err := skopeoCopyImage(ctx, sourceImage, authFile.Name(), targetImage, ic.imageSwapper.registryClient.Credentials()); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func skopeoCopyImage(ctx context.Context, src string, srcCeds string, dest string, destCreds string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	app := "skopeo"
+	args := []string{
+		"--override-os", "linux",
+		"copy",
+		"--all",
+		"--retry-times", "3",
+		"docker://" + src,
+		"docker://" + dest,
+	}
+
+	if len(srcCeds) > 0 {
+		args = append(args, "--src-authfile", srcCeds)
+	} else {
+		args = append(args, "--src-no-creds")
+	}
+
+	if len(destCreds) > 0 {
+		args = append(args, "--dest-creds", destCreds)
+	} else {
+		args = append(args, "--dest-no-creds")
+	}
+
+	output, err := exec.CommandContext(ctx, app, args...).CombinedOutput()
+
+	log.Ctx(ctx).
+		Trace().
+		Str("app", app).
+		Strs("args", args).
+		Bytes("output", output).
+		Msg("executed command to copy image")
+
+	return err
+}

--- a/pkg/webhook/image_copier_test.go
+++ b/pkg/webhook/image_copier_test.go
@@ -1,0 +1,116 @@
+package webhook
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/containers/image/v5/transports/alltransports"
+	"github.com/estahn/k8s-image-swapper/pkg/registry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestImageCopier_withDeadline(t *testing.T) {
+	mutator := NewImageSwapperWithOpts(
+		nil,
+		ImageCopyDeadline(8*time.Second),
+	)
+
+	imageSwapper, _ := mutator.(*ImageSwapper)
+
+	imageCopier := &ImageCopier{
+		imageSwapper: imageSwapper,
+		context:      context.Background(),
+	}
+
+	imageCopier = imageCopier.withDeadline()
+	deadline, hasDeadline := imageCopier.context.Deadline()
+
+	// test that a deadline has been set
+	assert.Equal(t, true, hasDeadline)
+
+	// test that the deadline is future
+	assert.GreaterOrEqual(t, deadline, time.Now())
+
+	// test that the context can be canceled
+	assert.NotEqual(t, nil, imageCopier.context.Done())
+
+	imageCopier.cancelContext()
+
+	_, ok := <-imageCopier.context.Done()
+	// test that the Done channel is closed, meaning the context is canceled
+	assert.Equal(t, false, ok)
+
+}
+
+func TestImageCopier_tasksTimeout(t *testing.T) {
+	ecrClient := new(mockECRClient)
+	ecrClient.On(
+		"CreateRepositoryWithContext",
+		mock.AnythingOfType("*context.timerCtx"),
+		&ecr.CreateRepositoryInput{
+			ImageScanningConfiguration: &ecr.ImageScanningConfiguration{
+				ScanOnPush: aws.Bool(true),
+			},
+			ImageTagMutability: aws.String("MUTABLE"),
+			RepositoryName:     aws.String("docker.io/library/init-container"),
+			RegistryId:         aws.String("123456789"),
+			Tags: []*ecr.Tag{
+				{
+					Key:   aws.String("CreatedBy"),
+					Value: aws.String("k8s-image-swapper"),
+				},
+			},
+		}).Return(mock.Anything)
+
+	registryClient, _ := registry.NewMockECRClient(ecrClient, "ap-southeast-2", "123456789.dkr.ecr.ap-southeast-2.amazonaws.com", "123456789", "arn:aws:iam::123456789:role/fakerole")
+
+	// image swapper with an instant timeout for testing purpose
+	mutator := NewImageSwapperWithOpts(
+		registryClient,
+		ImageCopyDeadline(0*time.Second),
+	)
+
+	imageSwapper, _ := mutator.(*ImageSwapper)
+
+	srcRef, _ := alltransports.ParseImageName("docker://library/init-container:latest")
+	imageCopier := &ImageCopier{
+		imageSwapper:    imageSwapper,
+		context:         context.Background(),
+		sourceImageRef:  srcRef,
+		targetImage:     "123456789.dkr.ecr.ap-southeast-2.amazonaws.com/docker.io/library/init-container:latest",
+		imagePullPolicy: corev1.PullAlways,
+		sourcePod: &corev1.Pod{
+			Spec: corev1.PodSpec{
+				ServiceAccountName: "service-account",
+				ImagePullSecrets:   []corev1.LocalObjectReference{},
+			},
+		},
+	}
+	imageCopier = imageCopier.withDeadline()
+
+	// test that copy steps generate timeout errors
+	var timeoutError error
+
+	timeoutError = imageCopier.run(imageCopier.taskCheckImage)
+	assert.Equal(t, context.DeadlineExceeded, timeoutError)
+
+	timeoutError = imageCopier.run(imageCopier.taskCreateRepository)
+	assert.Equal(t, context.DeadlineExceeded, timeoutError)
+
+	timeoutError = imageCopier.run(imageCopier.taskCopyImage)
+	assert.Equal(t, context.DeadlineExceeded, timeoutError)
+
+	timeoutError = imageCopier.taskCheckImage()
+	assert.Equal(t, context.DeadlineExceeded, timeoutError)
+
+	timeoutError = imageCopier.taskCreateRepository()
+	assert.Equal(t, context.DeadlineExceeded, timeoutError)
+
+	timeoutError = imageCopier.taskCopyImage()
+	assert.Equal(t, context.DeadlineExceeded, timeoutError)
+}

--- a/pkg/webhook/image_swapper.go
+++ b/pkg/webhook/image_swapper.go
@@ -178,8 +178,7 @@ func (p *ImageSwapper) Mutate(ctx context.Context, ar *kwhmodel.AdmissionReview,
 		Str("name", pod.Name).
 		Logger()
 
-	lctx := logger.
-		WithContext(ctx)
+	lctx := logger.WithContext(context.Background())
 
 	containerSets := []*[]corev1.Container{&pod.Spec.Containers, &pod.Spec.InitContainers}
 	for _, containerSet := range containerSets {


### PR DESCRIPTION
Fixes #421 

Creates a new `ImageCopier` object with its own `imagePullPolicy` to avoid a data race on the `container` object.

This new object is dedicated to the image copy process as it was done before but with its own subcontext and abstracted from the core mutation webhook processing. 

A new configurable `imageCopyDeadline` parameter has been added alongside an implementation of timeout throughout the different steps of the image copy. Every function called as part of the copy has been updated to include context evaluation and support abortion in case of context timeout. 
