### PR TITLE
fix: GAR registry domain skip logic

### DIFF
--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -24,6 +24,9 @@ type Client interface {
 	// Endpoint returns the domain of the registry
 	Endpoint() string
 	Credentials() string
+
+	// IsOrigin returns true if the imageRef originates from this registry
+	IsOrigin(imageRef ctypes.ImageReference) bool
 }
 
 type DockerConfig struct {
@@ -34,7 +37,7 @@ type AuthConfig struct {
 	Auth string `json:"auth,omitempty"`
 }
 
-// returns a registry client ready for use without the need to specify an implementation
+// NewClient returns a registry client ready for use without the need to specify an implementation
 func NewClient(r config.Registry) (Client, error) {
 	if err := config.CheckRegistryConfiguration(r); err != nil {
 		return nil, err

--- a/pkg/registry/ecr.go
+++ b/pkg/registry/ecr.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"github.com/containers/image/v5/docker/reference"
 	"net/http"
 	"os/exec"
 	"time"
@@ -262,6 +263,12 @@ func (e *ECRClient) ImageExists(ctx context.Context, imageRef ctypes.ImageRefere
 
 func (e *ECRClient) Endpoint() string {
 	return e.ecrDomain
+}
+
+// IsOrigin returns true if the references origin is from this registry
+func (e *ECRClient) IsOrigin(imageRef ctypes.ImageReference) bool {
+	domain := reference.Domain(imageRef.DockerReference())
+	return domain == e.Endpoint()
 }
 
 // requestAuthToken requests and returns an authentication token from ECR with its expiration date

--- a/pkg/registry/ecr_test.go
+++ b/pkg/registry/ecr_test.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"encoding/base64"
+	"github.com/containers/image/v5/transports/alltransports"
 	"testing"
 
 	"github.com/estahn/k8s-image-swapper/pkg/config"
@@ -19,4 +20,33 @@ func TestDockerConfig(t *testing.T) {
 	r, _ := GenerateDockerConfig(fakeRegistry)
 
 	assert.Equal(t, r, expected)
+}
+
+func TestECRIsOrigin(t *testing.T) {
+	type testCase struct {
+		input    string
+		expected bool
+	}
+	testcases := []testCase{
+		{
+			input:    "k8s.gcr.io/ingress-nginx/controller@sha256:9bba603b99bf25f6d117cf1235b6598c16033ad027b143c90fa5b3cc583c5713",
+			expected: false,
+		},
+		{
+			input:    "12345678912.dkr.ecr.us-east-1.amazonaws.com/k8s.gcr.io/ingress-nginx/controller@sha256:9bba603b99bf25f6d117cf1235b6598c16033ad027b143c90fa5b3cc583c5713",
+			expected: true,
+		},
+	}
+
+	fakeRegistry := NewDummyECRClient("us-east-1", "12345678912", "", config.ECROptions{}, []byte(""))
+
+	for _, testcase := range testcases {
+		imageRef, err := alltransports.ParseImageName("docker://" + testcase.input)
+
+		assert.NoError(t, err)
+
+		result := fakeRegistry.IsOrigin(imageRef)
+
+		assert.Equal(t, testcase.expected, result)
+	}
 }

--- a/pkg/registry/gar.go
+++ b/pkg/registry/gar.go
@@ -58,7 +58,7 @@ func NewGARClient(clientConfig config.GCP) (*GARClient, error) {
 	return client, nil
 }
 
-// repositories are not created for artifact registry
+// CreateRepository is empty since repositories are not created for artifact registry
 func (e *GARClient) CreateRepository(ctx context.Context, name string) error {
 	return nil
 }

--- a/pkg/registry/gar.go
+++ b/pkg/registry/gar.go
@@ -161,6 +161,11 @@ func (e *GARClient) Endpoint() string {
 	return e.garDomain
 }
 
+// IsOrigin returns true if the references origin is from this registry
+func (e *GARClient) IsOrigin(imageRef ctypes.ImageReference) bool {
+	return strings.HasPrefix(imageRef.DockerReference().String(), e.Endpoint())
+}
+
 // requestAuthToken requests and returns an authentication token from GAR with its expiration date
 func (e *GARClient) requestAuthToken() ([]byte, time.Time, error) {
 	ctx := context.Background()

--- a/pkg/registry/gar_test.go
+++ b/pkg/registry/gar_test.go
@@ -1,0 +1,37 @@
+package registry
+
+import (
+	"github.com/containers/image/v5/transports/alltransports"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGARIsOrigin(t *testing.T) {
+	type testCase struct {
+		input    string
+		expected bool
+	}
+	testcases := []testCase{
+		{
+			input:    "k8s.gcr.io/ingress-nginx/controller@sha256:9bba603b99bf25f6d117cf1235b6598c16033ad027b143c90fa5b3cc583c5713",
+			expected: false,
+		},
+		{
+			input:    "us-central1-docker.pkg.dev/gcp-project-123/main/k8s.gcr.io/ingress-nginx/controller@sha256:9bba603b99bf25f6d117cf1235b6598c16033ad027b143c90fa5b3cc583c5713",
+			expected: true,
+		},
+	}
+
+	fakeRegistry, _ := NewMockGARClient(nil, "us-central1-docker.pkg.dev/gcp-project-123/main")
+
+	for _, testcase := range testcases {
+		imageRef, err := alltransports.ParseImageName("docker://" + testcase.input)
+
+		assert.NoError(t, err)
+
+		result := fakeRegistry.IsOrigin(imageRef)
+
+		assert.Equal(t, testcase.expected, result)
+	}
+}

--- a/pkg/webhook/image_swapper.go
+++ b/pkg/webhook/image_swapper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/alitto/pond"
@@ -196,8 +197,8 @@ func (p *ImageSwapper) Mutate(ctx context.Context, ar *kwhmodel.AdmissionReview,
 				continue
 			}
 
-			// skip if the source and target registry domain are equal (e.g. same ECR registries)
-			if domain := reference.Domain(srcRef.DockerReference()); domain == p.registryClient.Endpoint() {
+			// skip if the source ref is within the target registry
+			if strings.HasPrefix(srcRef.DockerReference().String(), p.registryClient.Endpoint()) {
 				continue
 			}
 

--- a/pkg/webhook/image_swapper.go
+++ b/pkg/webhook/image_swapper.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/alitto/pond"
@@ -197,8 +196,8 @@ func (p *ImageSwapper) Mutate(ctx context.Context, ar *kwhmodel.AdmissionReview,
 				continue
 			}
 
-			// skip if the source ref is within the target registry
-			if strings.HasPrefix(srcRef.DockerReference().String(), p.registryClient.Endpoint()) {
+			// skip if the source originates from the target registry
+			if p.registryClient.IsOrigin(srcRef) {
 				log.Ctx(lctx).Debug().Str("registry", srcRef.DockerReference().String()).Msg("skip due to source and target being the same registry")
 				continue
 			}

--- a/pkg/webhook/image_swapper.go
+++ b/pkg/webhook/image_swapper.go
@@ -199,6 +199,7 @@ func (p *ImageSwapper) Mutate(ctx context.Context, ar *kwhmodel.AdmissionReview,
 
 			// skip if the source ref is within the target registry
 			if strings.HasPrefix(srcRef.DockerReference().String(), p.registryClient.Endpoint()) {
+				log.Ctx(lctx).Debug().Str("registry", srcRef.DockerReference().String()).Msg("skip due to source and target being the same registry")
 				continue
 			}
 

--- a/test/requests/admissionreview-simple.json
+++ b/test/requests/admissionreview-simple.json
@@ -51,6 +51,36 @@
                 "readOnly": true
               }
             ]
+          },
+          {
+            "image": "123456789.dkr.ecr.ap-southeast-2.amazonaws.com/k8s.gcr.io/ingress-nginx/controller:v0.43.0@sha256:9bba603b99bf25f6d117cf1235b6598c16033ad027b143c90fa5b3cc583c5713",
+            "imagePullPolicy": "Always",
+            "name": "skip-test-ecr",
+            "resources": {},
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "volumeMounts": [
+              {
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                "name": "default-token-fjtvr",
+                "readOnly": true
+              }
+            ]
+          },
+          {
+            "image": "us-central1-docker.pkg.dev/gcp-project-123/main/k8s.gcr.io/ingress-nginx/controller@sha256:9bba603b99bf25f6d117cf1235b6598c16033ad027b143c90fa5b3cc583c5713",
+            "imagePullPolicy": "Always",
+            "name": "skip-test-gar",
+            "resources": {},
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "volumeMounts": [
+              {
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                "name": "default-token-fjtvr",
+                "readOnly": true
+              }
+            ]
           }
         ],
         "dnsPolicy": "ClusterFirst",


### PR DESCRIPTION
The logic used to skip source images that are within the same domain as the ECR registry does not work with GAR since GAR uses paths to designate a "registry".

Update skip logic to use the entire path of the target endpoint when comparing to source image.