### PR TITLE
Ability to disable image copying (ImageCopyPolicy=none)

### DIFF
--- a/.k8s-image-swapper.yml
+++ b/.k8s-image-swapper.yml
@@ -15,6 +15,7 @@ imageSwapPolicy: exists
 # - delayed: Submits the copy job to a process queue and moves on.
 # - immediate: Submits the copy job to a process queue and waits for it to finish (deadline 8s).
 # - force: Attempts to immediately copy the image (deadline 8s).
+# - none: Do not copy the image.
 imageCopyPolicy: delayed
 
 source:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,6 +40,7 @@ The option `imageCopyPolicy` (default: `delayed`) defines the image copy strateg
 * `delayed`: Submits the copy job to a process queue and moves on.
 * `immediate`: Submits the copy job to a process queue and waits for it to finish (deadline defined by `imageCopyDeadline`).
 * `force`: Attempts to immediately copy the image (deadline defined by `imageCopyDeadline`).
+* `none`: Do not copy the image.
 
 ## ImageCopyDeadline
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,7 +38,7 @@ type Config struct {
 
 	DryRun            bool          `yaml:"dryRun"`
 	ImageSwapPolicy   string        `yaml:"imageSwapPolicy" validate:"oneof=always exists"`
-	ImageCopyPolicy   string        `yaml:"imageCopyPolicy" validate:"oneof=delayed immediate force"`
+	ImageCopyPolicy   string        `yaml:"imageCopyPolicy" validate:"oneof=delayed immediate force none"`
 	ImageCopyDeadline time.Duration `yaml:"imageCopyDeadline"`
 
 	Source Source   `yaml:"source"`

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -51,10 +51,11 @@ const (
 	ImageCopyPolicyDelayed = iota
 	ImageCopyPolicyImmediate
 	ImageCopyPolicyForce
+	ImageCopyPolicyNone
 )
 
 func (p ImageCopyPolicy) String() string {
-	return [...]string{"delayed", "immediate", "force"}[p]
+	return [...]string{"delayed", "immediate", "force", "none"}[p]
 }
 
 func ParseImageCopyPolicy(p string) (ImageCopyPolicy, error) {
@@ -65,6 +66,8 @@ func ParseImageCopyPolicy(p string) (ImageCopyPolicy, error) {
 		return ImageCopyPolicyImmediate, nil
 	case ImageCopyPolicy(ImageCopyPolicyForce).String():
 		return ImageCopyPolicyForce, nil
+	case ImageCopyPolicy(ImageCopyPolicyNone).String():
+		return ImageCopyPolicyNone, nil
 	}
 	return ImageCopyPolicyDelayed, fmt.Errorf("unknown image copy policy string: '%s', defaulting to delayed", p)
 }

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -69,6 +69,11 @@ func TestParseImageCopyPolicy(t *testing.T) {
 			want: ImageCopyPolicyForce,
 		},
 		{
+			name: "none",
+			args: args{p: "none"},
+			want: ImageCopyPolicyNone,
+		},
+		{
 			name:    "random-non-existent",
 			args:    args{p: "random-non-existent"},
 			want:    ImageCopyPolicyDelayed,

--- a/pkg/webhook/image_swapper.go
+++ b/pkg/webhook/image_swapper.go
@@ -234,6 +234,8 @@ func (p *ImageSwapper) Mutate(ctx context.Context, ar *kwhmodel.AdmissionReview,
 				p.copier.SubmitAndWait(imageCopier.withDeadline().start)
 			case types.ImageCopyPolicyForce:
 				imageCopier.withDeadline().start()
+			case types.ImageCopyPolicyNone:
+				// do not copy image
 			default:
 				panic("unknown imageCopyPolicy")
 			}


### PR DESCRIPTION
Implement ImageCopyPolicy=none

Useful for air-gapped environments that only need to mutate pods and should not be copying images to the target registry.