### PR TITLE
Bump golang from 1.18 to 1.20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3.7.0
       with:
-        version: v1.46.2
+        version: v1.55.2
         args: --timeout=5m
 
   test:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
 #  - id: doctoc
 #    args: ['--title', '## Table of Contents']
 - repo:  https://github.com/golangci/golangci-lint
-  rev: a3336890904cd3efa4f1c7e3f82ce207fe125a6f # v1.46.2
+  rev: v1.55.2
   hooks:
     - id: golangci-lint
       args: ['--timeout', '5m']

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -2,7 +2,7 @@
 
 {% block outdated %}
   You're not viewing the latest version.
-  <a href="{{ '../' ~ base_url }}"> 
+  <a href="{{ '../' ~ base_url }}">
     <strong>Click here to go to latest.</strong>
   </a>
 {% endblock %}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/estahn/k8s-image-swapper
 
-go 1.18
+go 1.20
 
 require (
 	cloud.google.com/go/artifactregistry v1.13.1


### PR DESCRIPTION
Golang 1.20 is the oldest version that is supported