### PR TITLE
fix: expire cache items after 24h+

### DIFF
--- a/pkg/registry/ecr.go
+++ b/pkg/registry/ecr.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"github.com/containers/image/v5/docker/reference"
+	"math/rand"
 	"net/http"
 	"os/exec"
 	"time"
@@ -159,7 +160,7 @@ func (e *ECRClient) CreateRepository(ctx context.Context, name string) error {
 		}
 	}
 
-	e.cache.Set(name, "", 1)
+	e.cache.SetWithTTL(name, "", 1, time.Duration(24*time.Hour))
 
 	return nil
 }
@@ -256,7 +257,7 @@ func (e *ECRClient) ImageExists(ctx context.Context, imageRef ctypes.ImageRefere
 
 	log.Ctx(ctx).Trace().Str("ref", ref).Msg("found in target repository")
 
-	e.cache.Set(ref, "", 1)
+	e.cache.SetWithTTL(ref, "", 1, 24*time.Hour+time.Duration(rand.Intn(180))*time.Minute)
 
 	return true
 }

--- a/pkg/registry/gar.go
+++ b/pkg/registry/gar.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"os/exec"
 	"strings"
 	"time"
@@ -152,7 +153,7 @@ func (e *GARClient) ImageExists(ctx context.Context, imageRef ctypes.ImageRefere
 
 	log.Ctx(ctx).Trace().Str("ref", ref).Msg("found in target repository")
 
-	e.cache.Set(ref, "", 1)
+	e.cache.SetWithTTL(ref, "", 1, 24*time.Hour+time.Duration(rand.Intn(180))*time.Minute)
 
 	return true
 }


### PR DESCRIPTION
Introduces TTL to cache items to prevent incorrect swaps. The TTL is 24h + random 180 minutes to prevent a cache stampede.

fixes #632