### PR TITLE
feat(registry): Add generic registry for source, not target

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -251,6 +251,11 @@ func initConfig() {
 		log.Err(err).Msg("failed to unmarshal the config file")
 	}
 
+	if err := config.CheckTargetRegistryConfiguration(cfg.Target); err != nil {
+		log.Err(err).Msg("invalid target configuration")
+		os.Exit(1)
+	}
+
 	//validate := validator.New()
 	//if err := validate.Struct(cfg); err != nil {
 	//	validationErrors := err.(validator.ValidationErrors)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -60,9 +60,21 @@ type Source struct {
 }
 
 type Registry struct {
-	Type string `yaml:"type"`
-	AWS  AWS    `yaml:"aws"`
-	GCP  GCP    `yaml:"gcp"`
+	Type    string  `yaml:"type"`
+	AWS     AWS     `yaml:"aws"`
+	GCP     GCP     `yaml:"gcp"`
+	Generic Generic `yaml:"generic"`
+}
+
+type Generic struct {
+	Name           string         `yaml:"name"`
+	GenericOptions GenericOptions `yaml:"genericOptions"`
+}
+
+type GenericOptions struct {
+	Domain   string `yaml:"domain"`
+	Username string `yaml:"username"`
+	Password string `yaml:"password"`
 }
 
 type AWS struct {
@@ -109,6 +121,10 @@ func (g *GCP) GarDomain() string {
 	return fmt.Sprintf("%s-docker.pkg.dev/%s/%s", g.Location, g.ProjectID, g.RepositoryID)
 }
 
+func (g *Generic) GenericDomain() string {
+	return g.GenericOptions.Domain
+}
+
 func (r Registry) Domain() string {
 	registry, _ := types.ParseRegistry(r.Type)
 	switch registry {
@@ -116,6 +132,8 @@ func (r Registry) Domain() string {
 		return r.AWS.EcrDomain()
 	case types.RegistryGCP:
 		return r.GCP.GarDomain()
+	case types.RegistryGeneric:
+		return r.Generic.GenericDomain()
 	default:
 		return ""
 	}
@@ -152,6 +170,17 @@ func CheckRegistryConfiguration(r Registry) error {
 		}
 	}
 
+	return nil
+}
+
+// provides detailed information about wrongly provided configuration (target specific)
+func CheckTargetRegistryConfiguration(r Registry) error {
+	registryType, err := types.ParseRegistry(r.Type)
+	if err != nil {
+		return fmt.Errorf("couldn't parse target registry type")
+	} else if registryType == types.RegistryGeneric {
+		return fmt.Errorf("generic registry not allowed as target: %s", r.Generic.Name)
+	}
 	return nil
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -150,6 +150,48 @@ source:
 			},
 		},
 		{
+			name: "should render generic source registry",
+			cfg: `
+source:
+  registries:
+    - type: "generic"
+      generic:
+        name: "dockerio"
+        genericOptions:
+          domain: "docker.io"
+          username: "testuser"
+          password: "testpass"
+`,
+			expCfg: Config{
+				Target: Registry{
+					Type: "aws",
+					AWS: AWS{
+						ECROptions: ECROptions{
+							ImageTagMutability: "MUTABLE",
+							ImageScanningConfiguration: ImageScanningConfiguration{
+								ImageScanOnPush: true,
+							},
+						},
+					},
+				},
+				Source: Source{
+                    Registries: []Registry{
+						{
+							Type: "generic",
+							Generic: Generic{
+								Name: "dockerio",
+								GenericOptions: GenericOptions{
+									Domain: "docker.io",
+									Username: "testuser",
+									Password: "testpass",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "should use previous defaults",
 			cfg: `
 target:

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -175,13 +175,13 @@ source:
 					},
 				},
 				Source: Source{
-                    Registries: []Registry{
+					Registries: []Registry{
 						{
 							Type: "generic",
 							Generic: Generic{
 								Name: "dockerio",
 								GenericOptions: GenericOptions{
-									Domain: "docker.io",
+									Domain:   "docker.io",
 									Username: "testuser",
 									Password: "testpass",
 								},

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -53,6 +53,8 @@ func NewClient(r config.Registry) (Client, error) {
 		return NewECRClient(r.AWS)
 	case types.RegistryGCP:
 		return NewGARClient(r.GCP)
+	case types.RegistryGeneric:
+		return NewGenericClient(r.Generic)
 	default:
 		return nil, fmt.Errorf(`registry of type "%s" is not supported`, r.Type)
 	}

--- a/pkg/registry/generic.go
+++ b/pkg/registry/generic.go
@@ -1,0 +1,66 @@
+package registry
+
+import (
+	"context"
+	"fmt"
+
+	ctypes "github.com/containers/image/v5/types"
+	"github.com/estahn/k8s-image-swapper/pkg/config"
+)
+
+type GenericClient struct {
+	options       config.GenericOptions
+}
+
+func NewGenericClient(clientConfig config.Generic) (*GenericClient, error) {
+	client := GenericClient{}
+
+	client.options = clientConfig.GenericOptions
+
+	return &client, nil
+}
+
+func (g *GenericClient) CreateRepository(ctx context.Context, name string) error {
+	return nil
+}
+
+func (g *GenericClient) RepositoryExists() bool {
+	return true
+}
+
+func (g *GenericClient) CopyImage(ctx context.Context, src ctypes.ImageReference, srcCreds string, dest ctypes.ImageReference, destCreds string) error {
+	panic("implement me")
+}
+
+func (g *GenericClient) PullImage() error {
+	panic("implement me")
+}
+
+func (g *GenericClient) PutImage() error {
+	panic("implement me")
+}
+
+func (g *GenericClient) ImageExists(ctx context.Context, ref ctypes.ImageReference) bool {
+	return true
+}
+
+// Endpoint returns the domain of the registry
+func (g *GenericClient) Endpoint() string {
+	return g.options.Domain
+}
+
+func (g *GenericClient) Credentials() string {
+  return fmt.Sprintf("%s:%s", g.options.Username, g.options.Password)
+}
+
+// IsOrigin returns true if the imageRef originates from this registry
+func (g *GenericClient) IsOrigin(imageRef ctypes.ImageReference) bool {
+	return true
+}
+
+// For testing purposes
+func NewDummyGenericClient(domain string, options config.GenericOptions) *GenericClient {
+	return &GenericClient{
+		options:       options,
+	}
+}

--- a/pkg/registry/generic.go
+++ b/pkg/registry/generic.go
@@ -9,7 +9,7 @@ import (
 )
 
 type GenericClient struct {
-	options       config.GenericOptions
+	options config.GenericOptions
 }
 
 func NewGenericClient(clientConfig config.Generic) (*GenericClient, error) {
@@ -50,7 +50,7 @@ func (g *GenericClient) Endpoint() string {
 }
 
 func (g *GenericClient) Credentials() string {
-  return fmt.Sprintf("%s:%s", g.options.Username, g.options.Password)
+	return fmt.Sprintf("%s:%s", g.options.Username, g.options.Password)
 }
 
 // IsOrigin returns true if the imageRef originates from this registry
@@ -61,6 +61,6 @@ func (g *GenericClient) IsOrigin(imageRef ctypes.ImageReference) bool {
 // For testing purposes
 func NewDummyGenericClient(domain string, options config.GenericOptions) *GenericClient {
 	return &GenericClient{
-		options:       options,
+		options: options,
 	}
 }

--- a/pkg/registry/generic_test.go
+++ b/pkg/registry/generic_test.go
@@ -15,7 +15,7 @@ func TestGenericDockerConfig(t *testing.T) {
 	expected := []byte("{\"auths\":{\"docker.io\":{\"auth\":\"" + fakeBase64Token + "\"}}}")
 
 	fakeRegistry := NewDummyGenericClient("docker.io", config.GenericOptions{
-		Domain: "docker.io",
+		Domain:   "docker.io",
 		Username: "username",
 		Password: "password",
 	})

--- a/pkg/registry/generic_test.go
+++ b/pkg/registry/generic_test.go
@@ -1,0 +1,26 @@
+package registry
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/estahn/k8s-image-swapper/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenericDockerConfig(t *testing.T) {
+	fakeToken := []byte("username:password")
+	fakeBase64Token := base64.StdEncoding.EncodeToString(fakeToken)
+
+	expected := []byte("{\"auths\":{\"docker.io\":{\"auth\":\"" + fakeBase64Token + "\"}}}")
+
+	fakeRegistry := NewDummyGenericClient("docker.io", config.GenericOptions{
+		Domain: "docker.io",
+		Username: "username",
+		Password: "password",
+	})
+
+	r, _ := GenerateDockerConfig(fakeRegistry)
+
+	assert.Equal(t, r, expected)
+}

--- a/pkg/secrets/kubernetes.go
+++ b/pkg/secrets/kubernetes.go
@@ -42,7 +42,7 @@ func NewImagePullSecretsResultWithDefaults(defaultImagePullSecrets []registry.Cl
 		if err != nil {
 			log.Err(err)
 		} else {
-			imagePullSecretsResult.Add(fmt.Sprintf("source-ecr-%d", index), dockerConfig)
+			imagePullSecretsResult.Add(fmt.Sprintf("source-registry-%d", index), dockerConfig)
 		}
 	}
 	return imagePullSecretsResult

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -8,10 +8,11 @@ const (
 	RegistryUnknown = iota
 	RegistryAWS
 	RegistryGCP
+	RegistryGeneric
 )
 
 func (p Registry) String() string {
-	return [...]string{"unknown", "aws", "gcp"}[p]
+	return [...]string{"unknown", "aws", "gcp", "generic"}[p]
 }
 
 func ParseRegistry(p string) (Registry, error) {
@@ -20,6 +21,8 @@ func ParseRegistry(p string) (Registry, error) {
 		return RegistryAWS, nil
 	case Registry(RegistryGCP).String():
 		return RegistryGCP, nil
+	case Registry(RegistryGeneric).String():
+		return RegistryGeneric, nil
 	}
 	return RegistryUnknown, fmt.Errorf("unknown target registry string: '%s', defaulting to unknown", p)
 }


### PR DESCRIPTION
This allows auth to a generic source registry, such as dockerhub.

This partially solves #50