### PR TITLE
Add new cacheTtlMinutes and cacheJitterMaxMinutes configuration options

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,10 +44,41 @@ The option `imageCopyPolicy` (default: `delayed`) defines the image copy strateg
 
 ## ImageCopyDeadline
 
+## Cache Configuration
+
+When caching is enabled, k8s-image-swapper caches the existence of images to reduce strain on the target registry.
+This means that if an image is deleted from the target registry, k8s-image-swapper will continue to think it exists until the cache expires.
+There are two settings that control this behavior:
+
+### Cache TTL
+
+The option `cacheTtlMinutes` (default: `1440` - 24 hours) defines how long image existence information is cached. Set to `0` to disable caching entirely.
+
+### Cache Jitter
+
+The option `cacheJitterMaxMinutes` (default: `180` - 3 hours) defines the maximum random time added to the TTL to prevent a cache stampede. When many cache entries expire at the same time, it can cause a sudden spike in registry requests. Adding random jitter helps spread these requests out.
+
+!!! example
+    ```yaml
+    # Cache for 4 hours (240 minutes) with up to 30 minutes of random jitter
+    cacheTtlMinutes: 240
+    cacheJitterMaxMinutes: 30
+
+    # Disable caching completely
+    cacheTtlMinutes: 0
+    cacheJitterMaxMinutes: 0
+    
+    # Default behavior if not specified:
+    # cacheTtlMinutes: 1440      # 24 hours
+    # cacheJitterMaxMinutes: 180 # 3 hours
+    ```
+
+!!! note
+    The actual cache duration for each entry will be: `cacheTtlMinutes + random(0 to cacheJitterMaxMinutes)` minutes
+
 The option `imageCopyDeadline` (default: `8s`) defines the duration after which the image copy if aborted.
 
 This option only applies for `immediate` and `force` image copy strategies.
-
 
 ## Source
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,10 +38,12 @@ type Config struct {
 
 	ListenAddress string
 
-	DryRun            bool          `yaml:"dryRun"`
-	ImageSwapPolicy   string        `yaml:"imageSwapPolicy" validate:"oneof=always exists"`
-	ImageCopyPolicy   string        `yaml:"imageCopyPolicy" validate:"oneof=delayed immediate force none"`
-	ImageCopyDeadline time.Duration `yaml:"imageCopyDeadline"`
+	DryRun                bool          `yaml:"dryRun"`
+	ImageSwapPolicy       string        `yaml:"imageSwapPolicy" validate:"oneof=always exists"`
+	ImageCopyPolicy       string        `yaml:"imageCopyPolicy" validate:"oneof=delayed immediate force none"`
+	ImageCopyDeadline     time.Duration `yaml:"imageCopyDeadline"`
+	CacheTtlMinutes       int           `yaml:"cacheTtlMinutes"`
+	CacheJitterMaxMinutes int           `yaml:"cacheJitterMaxMinutes"`
 
 	Source Source   `yaml:"source"`
 	Target Registry `yaml:"target"`
@@ -164,4 +166,6 @@ func SetViperDefaults(v *viper.Viper) {
 	v.SetDefault("Target.AWS.ECROptions.ImageScanningConfiguration.ImageScanOnPush", true)
 	v.SetDefault("Target.AWS.ECROptions.ImageTagMutability", "MUTABLE")
 	v.SetDefault("Target.AWS.ECROptions.EncryptionConfiguration.EncryptionType", "AES256")
+	v.SetDefault("CacheTtlMinutes", 1440)      // 24 hours
+	v.SetDefault("CacheJitterMaxMinutes", 180) // 3 hours
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -21,6 +21,8 @@ func TestConfigParses(t *testing.T) {
 			name: "should render empty config with defaults",
 			cfg:  "",
 			expCfg: Config{
+				CacheTtlMinutes:       1440,
+				CacheJitterMaxMinutes: 180,
 				Target: Registry{
 					Type: "aws",
 					AWS: AWS{
@@ -46,6 +48,8 @@ source:
     - jmespath: "obj.metadata.namespace != 'playground'"
 `,
 			expCfg: Config{
+				CacheTtlMinutes:       1440,
+				CacheJitterMaxMinutes: 180,
 				Target: Registry{
 					Type: "aws",
 					AWS: AWS{
@@ -85,6 +89,8 @@ target:
           value: B
 `,
 			expCfg: Config{
+				CacheTtlMinutes:       1440,
+				CacheJitterMaxMinutes: 180,
 				Target: Registry{
 					Type: "aws",
 					AWS: AWS{
@@ -129,6 +135,8 @@ source:
         region: "us-east-1"
 `,
 			expCfg: Config{
+				CacheTtlMinutes:       1440,
+				CacheJitterMaxMinutes: 180,
 				Target: Registry{
 					Type: "aws",
 					AWS: AWS{
@@ -178,6 +186,8 @@ target:
           value: B
 `,
 			expCfg: Config{
+				CacheTtlMinutes:       1440,
+				CacheJitterMaxMinutes: 180,
 				Target: Registry{
 					Type: "aws",
 					AWS: AWS{
@@ -201,6 +211,56 @@ target:
 									Key:   "A",
 									Value: "B",
 								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "should render custom cache settings",
+			cfg: `
+cacheTtlMinutes: 60
+cacheJitterMaxMinutes: 20
+`,
+			expCfg: Config{
+				CacheTtlMinutes:       60,
+				CacheJitterMaxMinutes: 20,
+				Target: Registry{
+					Type: "aws",
+					AWS: AWS{
+						ECROptions: ECROptions{
+							ImageTagMutability: "MUTABLE",
+							ImageScanningConfiguration: ImageScanningConfiguration{
+								ImageScanOnPush: true,
+							},
+							EncryptionConfiguration: EncryptionConfiguration{
+								EncryptionType: "AES256",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "should allow disabling cache",
+			cfg: `
+cacheTtlMinutes: 0        # Disable cache
+cacheJitterMaxMinutes: 0  # No jitter needed when cache is disabled
+`,
+			expCfg: Config{
+				CacheTtlMinutes:       0,
+				CacheJitterMaxMinutes: 0,
+				Target: Registry{
+					Type: "aws",
+					AWS: AWS{
+						ECROptions: ECROptions{
+							ImageTagMutability: "MUTABLE",
+							ImageScanningConfiguration: ImageScanningConfiguration{
+								ImageScanOnPush: true,
+							},
+							EncryptionConfiguration: EncryptionConfiguration{
+								EncryptionType: "AES256",
 							},
 						},
 					},

--- a/pkg/registry/gar_test.go
+++ b/pkg/registry/gar_test.go
@@ -1,10 +1,12 @@
 package registry
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/containers/image/v5/transports/alltransports"
-
+	"github.com/dgraph-io/ristretto"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -34,5 +36,60 @@ func TestGARIsOrigin(t *testing.T) {
 		result := fakeRegistry.IsOrigin(imageRef)
 
 		assert.Equal(t, testcase.expected, result)
+	}
+}
+
+func TestGarImageExistsCaching(t *testing.T) {
+	// Setup a test cache
+	cache, err := ristretto.NewCache(&ristretto.Config{
+		NumCounters: 1e7,     // number of keys to track frequency of (10M).
+		MaxCost:     1 << 30, // maximum cost of cache (1GB).
+		BufferItems: 64,      // number of keys per Get buffer.
+	})
+	assert.NoError(t, err)
+
+	tests := []struct {
+		name            string
+		cacheTtlMinutes int
+		expectCached    bool
+	}{
+		{
+			name:            "cache disabled when TTL is 0",
+			cacheTtlMinutes: 0,
+			expectCached:    false,
+		},
+		{
+			name:            "cache enabled with TTL and jitter",
+			cacheTtlMinutes: 60,
+			expectCached:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			client, err := NewMockGARClient(nil, "us-central1-docker.pkg.dev/test-project/repo")
+			assert.NoError(t, err)
+
+			// Setup cache
+			client.cache = cache
+			client.cacheTtlMinutes = tc.cacheTtlMinutes
+
+			// Create a test image reference and add to cache. Use 100ms as TTL
+			imageRef, err := alltransports.ParseImageName("docker://us-central1-docker.pkg.dev/test-project/repo/test-image:latest")
+			cache.SetWithTTL(imageRef.DockerReference().String(), true, 1, 100*time.Millisecond)
+			assert.NoError(t, err)
+
+			// Cache should be a hit
+			exists := client.ImageExists(ctx, imageRef)
+			assert.Equal(t, tc.expectCached, exists)
+
+			if tc.expectCached {
+				// Verify cache expiry
+				time.Sleep(time.Duration(150 * time.Millisecond)) // Use milliseconds for testing
+				_, found := client.cache.Get(imageRef.DockerReference().String())
+				assert.False(t, found, "cache entry should have expired")
+			}
+		})
 	}
 }


### PR DESCRIPTION
Add configurable cache TTL and jitter settings.

## Problem
Currently, the image existence cache has a hardcoded TTL of 24 hours with a 3-hour jitter. This can be problematic for users who:
- Need to adjust cache duration based on potential artifact cleanup policies
- Want to disable caching entirely
- Need to tune jitter settings to prevent cache stampede in their environment

## Solution
Added two new configuration options:
- `cacheTtlMinutes` (default: 1440 - 24 hours): Controls how long image existence information is cached
- `cacheJitterMaxMinutes` (default: 180 - 3 hours): Controls the maximum random time added to prevent cache stampede

Both settings are configurable via the `.k8s-image-swapper.yaml` config file.

Fixes #843