### PR TITLE
Skip copy for given container registry domain

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -108,6 +108,7 @@ A mutating webhook for Kubernetes, pointing the images to a new location.`,
 			webhook.ImageSwapPolicy(imageSwapPolicy),
 			webhook.ImageCopyPolicy(imageCopyPolicy),
 			webhook.ImageCopyDeadline(imageCopyDeadline),
+			webhook.ImageCopySkipRegistries(cfg.ImageCopySkipRegistries),
 		)
 		if err != nil {
 			log.Err(err).Msg("error creating webhook")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,10 +38,11 @@ type Config struct {
 
 	ListenAddress string
 
-	DryRun            bool          `yaml:"dryRun"`
-	ImageSwapPolicy   string        `yaml:"imageSwapPolicy" validate:"oneof=always exists"`
-	ImageCopyPolicy   string        `yaml:"imageCopyPolicy" validate:"oneof=delayed immediate force none"`
-	ImageCopyDeadline time.Duration `yaml:"imageCopyDeadline"`
+	DryRun                  bool          `yaml:"dryRun"`
+	ImageSwapPolicy         string        `yaml:"imageSwapPolicy" validate:"oneof=always exists"`
+	ImageCopyPolicy         string        `yaml:"imageCopyPolicy" validate:"oneof=delayed immediate force none"`
+	ImageCopyDeadline       time.Duration `yaml:"imageCopyDeadline"`
+	ImageCopySkipRegistries []string      `yaml:"skipRegistries"`
 
 	Source Source   `yaml:"source"`
 	Target Registry `yaml:"target"`


### PR DESCRIPTION
Since AWS has added more options for pull through cache on ECR.

I would prefer to use that but there a still unsupported image sources. Not all registries are supported so this provides the flexibility to skip the once ECR Pull through cache handles.

There is still a benefit to k8s-image-swapper since it supports the image swap on a pod level. Cause we want use tooling to detect changes to the images we use on a higher level than the pod.

![image](https://github.com/user-attachments/assets/737bdb1c-c81d-4921-aacf-e751c2ffdde9)
![image](https://github.com/user-attachments/assets/e00a7439-2a11-42ae-bad1-7b75b83fdc05)
