### PR TITLE
Add support for AWS China's different domain suffix

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,6 +23,7 @@ package config
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/spf13/viper"
@@ -102,7 +103,11 @@ type EncryptionConfiguration struct {
 }
 
 func (a *AWS) EcrDomain() string {
-	return fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com", a.AccountID, a.Region)
+	domain := "amazonaws.com"
+	if strings.HasPrefix(a.Region, "cn-") {
+		domain = "amazonaws.com.cn"
+	}
+	return fmt.Sprintf("%s.dkr.ecr.%s.%s", a.AccountID, a.Region, domain)
 }
 
 func (g *GCP) GarDomain() string {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -231,3 +231,44 @@ target:
 		})
 	}
 }
+
+func TestEcrDomain(t *testing.T) {
+	tests := []struct {
+		name   string
+		cfg    Config
+		domain string
+	}{
+		{
+			name: "commercial aws",
+			cfg: Config{
+				Target: Registry{
+					Type: "aws",
+					AWS: AWS{
+						AccountID: "123456789",
+						Region:    "ap-southeast-2",
+					},
+				},
+			},
+			domain: "123456789.dkr.ecr.ap-southeast-2.amazonaws.com",
+		},
+		{
+			name: "aws in china",
+			cfg: Config{
+				Target: Registry{
+					Type: "aws",
+					AWS: AWS{
+						AccountID: "123456789",
+						Region:    "cn-north-1",
+					},
+				},
+			},
+			domain: "123456789.dkr.ecr.cn-north-1.amazonaws.com.cn",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+			assert.Equal(test.cfg.Target.AWS.EcrDomain(), test.domain)
+		})
+	}
+}


### PR DESCRIPTION
Interestingly, this doesn't show up unless you are in "no copy" mode- it looks like in copy mode, k8s-image-mapper gets the docker URI from the authorization token, passes it through skopeo, and get it back, but where we're forced to generate the domain, we need a little extra magic.