### PR TITLE
Add the possibility to disable the automatic repository creation

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -108,6 +108,7 @@ A mutating webhook for Kubernetes, pointing the images to a new location.`,
 			webhook.ImageSwapPolicy(imageSwapPolicy),
 			webhook.ImageCopyPolicy(imageCopyPolicy),
 			webhook.ImageCopyDeadline(imageCopyDeadline),
+			webhook.CreateRepository(cfg.Target.CreateRepository),
 		)
 		if err != nil {
 			log.Err(err).Msg("error creating webhook")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -158,6 +158,9 @@ This section configures details about the image target.
 The option `target` allows to specify which type of registry you set as your target (AWS, GCP...).
 At the moment, `aws` and `gcp` are the only supported values.
 
+Setting `createRepository` to `false` will prevent `k8s-image-swapper` from creating repositories in the target registry.
+This way AWS creation templates can be used or premissions restricted to already existing repositories.
+
 ### AWS
 
 The option `target.aws` holds details about the target registry storing the images.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -61,9 +61,10 @@ type Source struct {
 }
 
 type Registry struct {
-	Type string `yaml:"type"`
-	AWS  AWS    `yaml:"aws"`
-	GCP  GCP    `yaml:"gcp"`
+	Type             string `yaml:"type"`
+	CreateRepository bool   `yaml:"createRepository"`
+	AWS              AWS    `yaml:"aws"`
+	GCP              GCP    `yaml:"gcp"`
 }
 
 type AWS struct {
@@ -167,6 +168,7 @@ func CheckRegistryConfiguration(r Registry) error {
 // SetViperDefaults configures default values for config items that are not set.
 func SetViperDefaults(v *viper.Viper) {
 	v.SetDefault("Target.Type", "aws")
+	v.SetDefault("Target.CreateRepository", true)
 	v.SetDefault("Target.AWS.ECROptions.ImageScanningConfiguration.ImageScanOnPush", true)
 	v.SetDefault("Target.AWS.ECROptions.ImageTagMutability", "MUTABLE")
 	v.SetDefault("Target.AWS.ECROptions.EncryptionConfiguration.EncryptionType", "AES256")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -22,7 +22,8 @@ func TestConfigParses(t *testing.T) {
 			cfg:  "",
 			expCfg: Config{
 				Target: Registry{
-					Type: "aws",
+					Type:             "aws",
+					CreateRepository: true,
 					AWS: AWS{
 						ECROptions: ECROptions{
 							ImageTagMutability: "MUTABLE",
@@ -47,7 +48,8 @@ source:
 `,
 			expCfg: Config{
 				Target: Registry{
-					Type: "aws",
+					Type:             "aws",
+					CreateRepository: true,
 					AWS: AWS{
 						ECROptions: ECROptions{
 							ImageTagMutability: "MUTABLE",
@@ -86,7 +88,8 @@ target:
 `,
 			expCfg: Config{
 				Target: Registry{
-					Type: "aws",
+					Type:             "aws",
+					CreateRepository: true,
 					AWS: AWS{
 						AccountID: "123456789",
 						Region:    "ap-southeast-2",
@@ -130,7 +133,8 @@ source:
 `,
 			expCfg: Config{
 				Target: Registry{
-					Type: "aws",
+					Type:             "aws",
+					CreateRepository: true,
 					AWS: AWS{
 						ECROptions: ECROptions{
 							ImageTagMutability: "MUTABLE",
@@ -179,7 +183,8 @@ target:
 `,
 			expCfg: Config{
 				Target: Registry{
-					Type: "aws",
+					Type:             "aws",
+					CreateRepository: true,
 					AWS: AWS{
 						AccountID: "123456789",
 						Region:    "ap-southeast-2",
@@ -201,6 +206,30 @@ target:
 									Key:   "A",
 									Value: "B",
 								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "should disable repository creation",
+			cfg: `
+target:
+  createRepository: false
+`,
+			expCfg: Config{
+				Target: Registry{
+					Type:             "aws",
+					CreateRepository: false,
+					AWS: AWS{
+						ECROptions: ECROptions{
+							ImageTagMutability: "MUTABLE",
+							ImageScanningConfiguration: ImageScanningConfiguration{
+								ImageScanOnPush: true,
+							},
+							EncryptionConfiguration: EncryptionConfiguration{
+								EncryptionType: "AES256",
 							},
 						},
 					},

--- a/pkg/webhook/image_copier.go
+++ b/pkg/webhook/image_copier.go
@@ -101,6 +101,10 @@ func (ic *ImageCopier) taskCheckImage() error {
 }
 
 func (ic *ImageCopier) taskCreateRepository() error {
+	if !ic.imageSwapper.createRepository {
+		return nil
+	}
+
 	createRepoName := reference.TrimNamed(ic.sourceImageRef.DockerReference()).String()
 
 	return ic.imageSwapper.registryClient.CreateRepository(ic.context, createRepoName)

--- a/pkg/webhook/image_swapper.go
+++ b/pkg/webhook/image_swapper.go
@@ -61,6 +61,13 @@ func ImageCopyDeadline(deadline time.Duration) Option {
 	}
 }
 
+// CreateRepository allows to pass the createRepository option
+func CreateRepository(createRepository bool) Option {
+	return func(swapper *ImageSwapper) {
+		swapper.createRepository = createRepository
+	}
+}
+
 // Copier allows to pass the copier option
 func Copier(pool *pond.WorkerPool) Option {
 	return func(swapper *ImageSwapper) {
@@ -81,12 +88,13 @@ type ImageSwapper struct {
 	copier            *pond.WorkerPool
 	imageCopyDeadline time.Duration
 
-	imageSwapPolicy types.ImageSwapPolicy
-	imageCopyPolicy types.ImageCopyPolicy
+	imageSwapPolicy  types.ImageSwapPolicy
+	imageCopyPolicy  types.ImageCopyPolicy
+	createRepository bool
 }
 
 // NewImageSwapper returns a new ImageSwapper initialized.
-func NewImageSwapper(registryClient registry.Client, imagePullSecretProvider secrets.ImagePullSecretsProvider, filters []config.JMESPathFilter, imageSwapPolicy types.ImageSwapPolicy, imageCopyPolicy types.ImageCopyPolicy, imageCopyDeadline time.Duration) kwhmutating.Mutator {
+func NewImageSwapper(registryClient registry.Client, imagePullSecretProvider secrets.ImagePullSecretsProvider, filters []config.JMESPathFilter, imageSwapPolicy types.ImageSwapPolicy, imageCopyPolicy types.ImageCopyPolicy, imageCopyDeadline time.Duration, createRepository bool) kwhmutating.Mutator {
 	return &ImageSwapper{
 		registryClient:          registryClient,
 		imagePullSecretProvider: imagePullSecretProvider,
@@ -95,6 +103,7 @@ func NewImageSwapper(registryClient registry.Client, imagePullSecretProvider sec
 		imageSwapPolicy:         imageSwapPolicy,
 		imageCopyPolicy:         imageCopyPolicy,
 		imageCopyDeadline:       imageCopyDeadline,
+		createRepository:        createRepository,
 	}
 }
 
@@ -106,6 +115,7 @@ func NewImageSwapperWithOpts(registryClient registry.Client, opts ...Option) kwh
 		filters:                 []config.JMESPathFilter{},
 		imageSwapPolicy:         types.ImageSwapPolicyExists,
 		imageCopyPolicy:         types.ImageCopyPolicyDelayed,
+		createRepository:        true,
 	}
 
 	for _, opt := range opts {
@@ -132,8 +142,8 @@ func NewImageSwapperWebhookWithOpts(registryClient registry.Client, opts ...Opti
 	return kwhmutating.NewWebhook(mcfg)
 }
 
-func NewImageSwapperWebhook(registryClient registry.Client, imagePullSecretProvider secrets.ImagePullSecretsProvider, filters []config.JMESPathFilter, imageSwapPolicy types.ImageSwapPolicy, imageCopyPolicy types.ImageCopyPolicy, imageCopyDeadline time.Duration) (webhook.Webhook, error) {
-	imageSwapper := NewImageSwapper(registryClient, imagePullSecretProvider, filters, imageSwapPolicy, imageCopyPolicy, imageCopyDeadline)
+func NewImageSwapperWebhook(registryClient registry.Client, imagePullSecretProvider secrets.ImagePullSecretsProvider, filters []config.JMESPathFilter, imageSwapPolicy types.ImageSwapPolicy, imageCopyPolicy types.ImageCopyPolicy, imageCopyDeadline time.Duration, createRepository bool) (webhook.Webhook, error) {
+	imageSwapper := NewImageSwapper(registryClient, imagePullSecretProvider, filters, imageSwapPolicy, imageCopyPolicy, imageCopyDeadline, createRepository)
 	mt := kwhmutating.MutatorFunc(imageSwapper.Mutate)
 	mcfg := kwhmutating.WebhookConfig{
 		ID:      "k8s-image-swapper",


### PR DESCRIPTION
This adds the possibility to disable the automatic repository creation.
Use cases are
* Use [AWS repository creation templates](https://docs.aws.amazon.com/AmazonECR/latest/userguide/repository-creation-templates.html) and their associated tags and settings to create repos (can do more and no config duplication needed)
* Restrict upload of images to certain, already existing, repositories, so you can also give fewer privileges to the operator.